### PR TITLE
Align outbound content-type to the payload type

### DIFF
--- a/spring-cloud-starter-stream-processor-transform/src/main/java/org/springframework/cloud/stream/app/transform/processor/TransformProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-transform/src/main/java/org/springframework/cloud/stream/app/transform/processor/TransformProcessorConfiguration.java
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Processor;
-import org.springframework.integration.annotation.Transformer;
+import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 
 /**
@@ -37,7 +37,7 @@ public class TransformProcessorConfiguration {
 	@Autowired
 	private TransformProcessorProperties properties;
 
-	@Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
+	@ServiceActivator(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
 	public Object transform(Message<?> message) {
 		return properties.getExpression().getValue(message);
 	}

--- a/spring-cloud-starter-stream-processor-transform/src/test/java/org/springframework/cloud/stream/app/transform/processor/TransformProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-transform/src/test/java/org/springframework/cloud/stream/app/transform/processor/TransformProcessorIntegrationTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.stream.app.transform.processor;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -26,6 +29,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.integration.config.SpelFunctionFactoryBean;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -83,6 +87,19 @@ public abstract class TransformProcessorIntegrationTests {
 			assertNotNull(this.xpathSpelFunctionFactoryBean);
 			this.channels.input().send(new GenericMessage<Object>("hello"));
 			assertThat(this.collector.forChannel(this.channels.output()), receivesPayloadThat(is("HELLO")));
+		}
+	}
+
+	@SpringBootTest("transformer.expression=new String(payload)")
+	public static class PayloadTypeDifferentFromOutputContentTypeTests extends TransformProcessorIntegrationTests {
+
+		@Test
+		public void test() {
+			Map<String, Object> headers = new HashMap<>();
+			headers.put(MessageHeaders.CONTENT_TYPE, "application/octet-stream");
+			channels.input().send(new GenericMessage<Object>("hello".getBytes(), new MessageHeaders(headers)));
+
+			assertThat(collector.forChannel(channels.output()), receivesPayloadThat(is("hello")));
 		}
 	}
 


### PR DESCRIPTION
If the outbound payload type is different from the inbound such then
the outbound content-type header should be aligned with the new payload type.
    
Discrepancy between the outbound payload type and the content-type metadata
may cause selecting incorrect message converter and therefore fail to encode
the outbound message into an appropriate wire format.
    
Due to https://jira.spring.io/browse/INT-4397 the @Transfomer annotated processors
blindly copy their input message headers into the output headers with no
regards of the outbound payload type.
    
The implementation of the @ServiceActivator doesn't suffer from this problem and can
be used as drop-in workaround.
    
Resolves #3
