### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/README.adoc
+++ b/README.adoc
@@ -8,4 +8,4 @@ include::spring-cloud-starter-stream-processor-transform/README.adoc[]
 
 Do not attempt to use/build from `master`; the `master` branch is currently undergoing redesign to adapt to Spring Boot and Spring Cloud 2.0 stack. You'd notice discrepencies and/or test failures.
 
-Please use/build the 1.3.x branch or the http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/[Celsius.SR1 release] of the applications - it is the latest GA release.
+Please use/build the 1.3.x branch or the https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/[Celsius.SR1 release] of the applications - it is the latest GA release.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/ with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/ ([https](https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).